### PR TITLE
Fix dialyzer warnings and fix bug in jsx_decoder:unescape/5

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -107,7 +107,7 @@ prettify(Source) -> format(Source, [space, {indent, 2}]).
 
 is_json(Source) -> is_json(Source, []).
 
--spec is_json(Source::any(), Config::jsx_verify:config()) -> boolean() | {incomplete, decoder()}.
+-spec is_json(Source::any(), Config::jsx_config:config() | []) -> boolean() | {incomplete, decoder()}.
 
 is_json(Source, Config) -> jsx_verify:is_json(Source, Config).
 
@@ -116,7 +116,7 @@ is_json(Source, Config) -> jsx_verify:is_json(Source, Config).
 
 is_term(Source) -> is_term(Source, []).
 
--spec is_term(Source::any(), Config::jsx_verify:config()) -> boolean() | {incomplete, encoder()}.
+-spec is_term(Source::any(), Config::jsx_config:config() | []) -> boolean() | {incomplete, encoder()}.
 
 is_term(Source, Config) -> jsx_verify:is_term(Source, Config).
 

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -36,9 +36,9 @@
 -type handler_type(Handler) ::
     fun((jsx:json_text() | end_stream |
          jsx:json_term(),
-         {decoder, any(), module(), null | list(), list()} |
-         {parser, any(), module(), list()} |
-         {encoder, any(), module()},
+         {decoder, any(), {module(), any()}, null | list(), list()} |
+         {parser, any(), {module(), any()}, list()} |
+         {encoder, any(), {module(), any()}},
          list({pre_encode, fun((any()) -> any())} |
               {error_handler, Handler} |
               {incomplete_handler, Handler} |

--- a/src/jsx_consult.erl
+++ b/src/jsx_consult.erl
@@ -81,17 +81,17 @@ consult(File, Config) when is_list(Config) ->
 
 
 -type state() :: {list(), #config{}}.
--spec init(Config::proplists:proplist()) -> state().
+-spec init(Config::proplists:proplist()) -> {[], proplists:proplist(), state()}.
 
 init(Config) -> {[], Config, jsx_to_term:start_term(Config)}.
 
 
--spec reset(State::state()) -> state().
+-spec reset(State::{list(), proplists:proplist(), any()}) -> {list(), proplists:proplist(), state()}.
 
 reset({Acc, Config, _}) -> {Acc, Config, jsx_to_term:start_term(Config)}.
 
 
--spec handle_event(Event::any(), State::state()) -> state().
+-spec handle_event(Event::any(), State::{list(), #config{}, state()}) -> {list(), #config{}, state()}.
 
 handle_event(end_json, {Acc, Config, State}) ->
     {[jsx_to_term:get_value(State)] ++ Acc, Config, State};

--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -755,9 +755,9 @@ unescape(<<$u, F, A, B, C, ?rsolidus, $u, G, X, Y, Z, Rest/binary>>, Handler, Ac
     Low = erlang:list_to_integer([$d, X, Y, Z], 16),
     Codepoint = (High - 16#d800) * 16#400 + (Low - 16#dc00) + 16#10000,
     string(Rest, Handler, [Acc, <<Codepoint/utf8>>], Stack, Config);
-unescape(<<$u, F, A, B, C, ?rsolidus, $u, W, X, Y, Z, Rest/binary>>, Handler, Acc, Stack, Config)
+unescape(<<$u, D, A, B, C, ?rsolidus, $u, W, X, Y, Z, Rest/binary>>, Handler, Acc, Stack, Config)
         when (A == $8 orelse A == $9 orelse A == $a orelse A == $b orelse A == $A orelse A == $B),
-            (F == $d orelse F == $D),
+            (D == $d orelse D == $D),
             ?is_hex(B), ?is_hex(C), ?is_hex(W), ?is_hex(X), ?is_hex(Y), ?is_hex(Z)
         ->
     case Config#config.strict_utf8 of
@@ -1970,6 +1970,22 @@ return_tail_test_() ->
                 {incomplete, F} = jsx:decode(<<"{">>, [return_tail, stream]),
                 F(<<"}">>)
             end
+        )}
+    ].
+
+front_backslash_test_() ->
+    [
+        {"front_backslash with front backslash", ?_assertEqual(
+            ok,
+            jsx:decode(<<"{\"", 16#5c, "udabc", 16#5c, "u0000\":false}">>,
+                       [strict,
+                        {error_handler, fun jsx_config:fake_error_handler/3}])
+        )},
+        {"front_backslash without front backslash", ?_assertEqual(
+            [{<<117,100,97,98,99,0>>,false}],
+            jsx:decode(<<"{\"udabc", 16#5c, "u0000\":false}">>,
+                       [strict,
+                        {error_handler, fun jsx_config:fake_error_handler/3}])
         )}
     ].
 

--- a/src/jsx_verify.erl
+++ b/src/jsx_verify.erl
@@ -27,11 +27,7 @@
 -export([init/1, handle_event/2]).
 
 
--type config() :: list().
--export_type([config/0]).
-
-
--spec is_json(Source::binary(), Config::config()) -> true | false | {incomplete, jsx:decoder()}.
+-spec is_json(Source::binary(), Config::jsx_config:config() | []) -> true | false | {incomplete, jsx:decoder()}.
 
 is_json(Source, Config) when is_list(Config) ->
     try (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config)))(Source)
@@ -39,7 +35,7 @@ is_json(Source, Config) when is_list(Config) ->
     end.
 
 
--spec is_term(Source::any(), Config::config()) -> true | false | {incomplete, jsx:encoder()}.
+-spec is_term(Source::any(), Config::jsx_config:config() | []) -> true | false | {incomplete, jsx:encoder()}.
 
 is_term(Source, Config) when is_list(Config) ->
     try (jsx:encoder(?MODULE, Config, jsx_config:extract_config(Config)))(Source)


### PR DESCRIPTION
Thanks to `Dialyzer` and @elbrujohalcon a **bug** was found (and fixed)
in `jsx_decoder:unescape/5`. The bug in question is with a variable (`F`)
in the function's header pattern match that happened to be the same variable
name used inside `?error` macro that is called from this function. The issue
was fixed by renaming `F` to `D` that is actually the character being matched.
A couple of tests were added to test the bug is fixed as well.